### PR TITLE
Fixed Vibrate, Saving, Touch-disable

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,3 @@
-
 #define OSSM 1
 
 #define CUM 2
@@ -43,10 +42,6 @@ OneButton Button1(35, false); //MX Button
 OneButton Button2(36, false); //Encoder Left
 OneButton Button3(34, false, true); //Encoder Right
 #endif
-
-
-
-#define Encoder_MAP 144
 
 #define LV_HOR_RES_MAX 320
 #define LV_VER_RES_MAX 240

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -898,6 +898,7 @@ void ui_Home_screen_init(void)
 
     ui_homestrokeslider = lv_slider_create(ui_StrokeL);
     lv_slider_set_range(ui_homestrokeslider, 0, maxdepthinmm);
+    lv_bar_set_mode(ui_homestrokeslider, LV_BAR_MODE_RANGE);
 
     lv_obj_set_width(ui_homestrokeslider, 130);
     lv_obj_set_height(ui_homestrokeslider, 10);


### PR DESCRIPTION
EEPROM function is being deprecated for the ESP32, replaced it's functions with its replacement, Preferences.h.

There were two Void Vibrate() functions, one empty that was being called, and a second one with content that was missing a delay and thus wouldn't have worked anyway. Fixed it by moving everything to the first one and adding a delay. Added passable commands while at it, for more customizable vibration feedback if/where desired.

Touchscreen-disable checks were querying a bool that got never actually written to as far as i could find. Now checks the actual Checkbox state that gets properly written to memory as well.

Since saving does not requite rebooting anymore, added a check to only reboot if the Theme gets changed. Downside is, if Vibrate is disabled, There is a lack of conformation. (button has a slight lighter tone for a split second, but for the most part your finger covers that up) Could make it so that it always vibrates, or always play a tone on save, but neither might be desirable (when wanting to use the remote as quietly as possible for instance).